### PR TITLE
Fix MacTeX package name in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,7 +22,7 @@ brew update
 echo "Warning: Installing MacTeX takes a long time (large download). Continue? [y/n]"
 read -r confirm
 if [[ "$confirm" =~ ^([yY][eE][sS]|[yY])$ ]]; then
-    brew install --cask mactex-no-ghostscript
+    brew install --cask mactex-no-gui
 else
     echo "Skipping MacTeX installation."
 fi


### PR DESCRIPTION
The package `mactex-no-ghostscript` does not exist in Homebrew. The correct package name is `mactex-no-gui` which provides the full TeX Live distribution without GUI applications.

This fixes the setup script to use the correct package name.